### PR TITLE
Remove the signature step since it fails

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,4 +1,4 @@
-name: Docker Image CI
+name: Docker Image Build
 
 on:
   push:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -77,17 +77,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-
-      # Sign the resulting Docker image digest except on PRs.
-      # This will only write to the public Rekor transparency log when the Docker
-      # repository is public to avoid leaking data.  If you would like to publish
-      # transparency data even for private images, pass --force to cosign below.
-      # https://github.com/sigstore/cosign
-      - name: Sign the published Docker image
-        if: ${{ github.event_name != 'pull_request' }}
-        env:
-          COSIGN_EXPERIMENTAL: "true"
-        # This step uses the identity token to provision an ephemeral certificate
-        # against the sigstore community Fulcio instance.
-        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,4 +1,4 @@
-name: Docker
+name: Docker Image Publish
 
 # This workflow uses actions that are not certified by GitHub.
 # They are provided by a third-party and are governed by

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,13 +1,6 @@
 name: Docker Image Publish
 
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 on:
-  schedule:
-    - cron: '25 9 * * *'
   push:
     branches: [ "main" ]
     # Publish semver tags as releases.


### PR DESCRIPTION
The signature step currently fails with the following:
```
Successfully verified SCT...

	The sigstore service, hosted by sigstore a Series of LF Projects, LLC, is provided pursuant to the Hosted Project Tools Terms of Use, available at https://lfprojects.org/policies/hosted-project-tools-terms-of-use/.
	Note that if your submission includes personal data associated with this signed artifact, it will be part of an immutable record.
	This may include the email address associated with the account with which you authenticate your contractual Agreement.
	This information will be used for signing this artifact and will be stored in public transparency logs and cannot be removed later, and is subject to the Immutable Record notice at https://lfprojects.org/policies/hosted-project-tools-immutable-records/.

By typing 'y', you attest that (1) you are not submitting the personal data of any other person; and (2) you understand and agree to the statement and the Agreement terms at the URLs listed above.
Are you sure you would like to continue? [y/N] Error: signing [ghcr.io/allenporter/k8s-gitops-env:main@sha256:40e229fa2294dcfbc11b8ee378eb106cf163aad74b520fece16fed3ad1ffc2d8]: signing digest: should upload to tlog: user declined the prompt
main.go:74: error during command execution: signing [ghcr.io/allenporter/k8s-gitops-env:main@sha256:40e229fa2294dcfbc11b8ee378eb106cf163aad74b520fece16fed3ad1ffc2d8]: signing digest: should upload to tlog: user declined the prompt
Error: Process completed with exit code 1[23](https://github.com/allenporter/k8s-gitops-env/actions/runs/4715173272/jobs/8361990962#step:8:24).
```

Since this was created by the github action template in the marketplace, it seems odd that it would fail. This looks similar to what others have so i'm not sure what was missing, and i can't find others with this problem yet.