### PR TITLE
Update terraform renovatebot versioning string matching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN cd /usr/local/bin/ && \
     chmod +x kubectl
 RUN kubectl version --client=true
 
-# renovate: datasource=github-releases depName=hashicorp/terraform
+# renovate: datasource=github-releases depName=hashicorp/terraform extractVersion=^v(?<version>.+)$
 ARG TERRAFORM_VERSION=1.4.5
 RUN mkdir -p /src && \
     cd /src && \


### PR DESCRIPTION
The intent is to fix failures in https://github.com/allenporter/k8s-gitops-env/pull/22