### PR TITLE
Fix apt-get docker command to correctly local vs remote cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 
 FROM ubuntu:jammy-20230308
 
-RUN apt-get update --fix-missing && apt-get upgrade -y
-RUN apt-get install -y --fix-missing \
+RUN apt-get update --fix-missing && \
+    apt-get upgrade -y && \
+    apt-get install -y --fix-missing \
         curl \
         unzip \
         software-properties-common \
@@ -10,7 +11,6 @@ RUN apt-get install -y --fix-missing \
         bind9-dnsutils \
         python3-pip
 
-RUN add-apt-repository ppa:deadsnakes/ppa
 # Version supported by base image
 ARG GO_VERSION=1.18
 RUN apt-get install -y \

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ be able to operate on the cluster:
  - [X] gcloud auth: Terraform state, secret management?
  - [X] proxmox password
  - [X] ssh keys
- - [ ] kubernetes client certs
+ - [X] kubernetes client certs
  - [X] ansible inventory
  - [ ] sops keys
 


### PR DESCRIPTION
Fix apt-get docker command to correctly local vs remote cache. This addresses issues where there are 404s trying to fetch images where the local repo and external repo are our of sync.